### PR TITLE
Hostvars support, cgroup fixes, templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@ It provides tooling to create Molecule testing scenarios via the `init` role, an
 
 When utilizing an image with systemd support (systemd packages are installed, etc.), the `docker_platform` role supports the creation of Docker containers with a functional Systemd implementation, which can be used to test Ansible code that makes use of Systemd services or related functionality.
 
+# Table of Contents
+
+- [Ansible Collection - syndr.molecule](#ansible-collection---syndrmolecule)
+- [What is Molecule?](#what-is-molecule)
+- [Using this collection](#using-this-collection)
+  - [Host Requirements](#host-requirements)
+  - [Project requirements](#project-requirements)
+    - [Standalone roles](#standalone-roles)
+    - [Collections](#collections)
+    - [Monoliths](#monoliths)
+      - [Testing roles and playbooks within a monolithic project](#testing-roles-and-playbooks-within-a-monolithic-project)
+    - [Playbooks](#playbooks)
+- [Using Molecule](#using-molecule)
+  - [Ansible Tags](#ansible-tags)
+- [Contributing](#contributing)
+
 # What is Molecule?
 
 > Molecule project is designed to aid in the development and testing of Ansible roles.
@@ -26,6 +42,8 @@ Some resources on Molecule can be found here:
 > This [RedHat article](https://developers.redhat.com/articles/2023/09/13/introducing-ansible-molecule-ansible-automation-platform#) has some more information on this change.
 >
 > When reading the above referenced articles, keep in mind their publishing dates, and that there may have been breaking changes to Molecule's functionality since that time!
+
+More tips on using Molecule can be found [below](#using-molecule).
 
 # Using this collection
 
@@ -246,6 +264,33 @@ It also adds the following directories to the collection path configuration (pat
 * `./collections`
 * `./../collections`
 * `./../../collections`
+
+# Using Molecule
+
+The most common Molecule commands that you will likely use are:
+
+```bash
+molecule create     # Create the test infrastructure, as defined in molecule.yml
+molecule converge   # Run the plays from converge.yml (launch your role/playbook)
+molecule verify     # Run the plays from verify.yml (test for desired state)
+molecule test       # Run the full test sequence
+```
+
+## Ansible Tags
+
+If [tags](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_tags.html) are used in your code to enable/disable certian functionality, they must be specified on the command line when running Molecule commands. To do so, use the `--` [command line option](https://ansible.readthedocs.io/projects/molecule/usage/#test-sequence-commands) to pass commands through to `ansible-playbook`.
+
+For example:
+
+```bash
+molecule test -- --tags the-cheese
+```
+
+Or running `converge` using a non-default scenario:
+
+```bash
+molecule converge -s pb-the_toaster -- --tags sourdough
+```
 
 # Contributing
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: syndr
 name: molecule
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.3.0
+version: 1.3.0-devel
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: syndr
 name: molecule
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.3.0-devel
+version: 1.3.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/molecule/default/collections.yml
+++ b/molecule/default/collections.yml
@@ -2,5 +2,5 @@
 
 collections:
   - name: community.docker
-  - name: {{ ansible_collection_name }}
+  - name: syndr.molecule
 

--- a/molecule/default/collections.yml
+++ b/molecule/default/collections.yml
@@ -1,6 +1,6 @@
 ---
 
 collections:
-  - community.docker
-  - syndr.molecule
+  - name: community.docker
+  - name: syndr.molecule
 

--- a/molecule/default/collections.yml
+++ b/molecule/default/collections.yml
@@ -2,5 +2,5 @@
 
 collections:
   - name: community.docker
-  - name: syndr.molecule
+  - name: {{ ansible_collection_name }}
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -46,7 +46,7 @@
           ansible.builtin.set_fact:
             test_prepare_fact: "{{ ansible_local.molecule.test_prepare_fact }}"
 
-    - name: Add your project test configuration here
+    - name: Dump the vars
       ansible.builtin.debug:
-        msg: Typically this will be via the ansible.builtin.include_role module or via import_playbook
+        var: testvar
 

--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -11,7 +11,8 @@
         docker_platform_image: "{{ item.image }}"
         docker_platform_systemd: "{{ item.systemd | default(false) }}"
         docker_platform_modify_image: "{{ item.modify_image | default(false) }}"
-        docker_platform_privileged: "{{ item.privileged | default (false) }}"
+        docker_platform_privileged: "{{ item.privileged | default(false) }}"
+        docker_platform_hostvars: "{{ item.hostvars | default({}) }}"
         docker_platform_state: present
       loop: "{{ molecule_yml.platforms }}"
       loop_control:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,6 +13,8 @@ platforms:
     systemd: True
     modify_image: False
     privileged: False
+    hostvars:
+      testvar: stuff
 provisioner:
   name: ansible
   log: True

--- a/roles/docker_platform/defaults/main.yml
+++ b/roles/docker_platform/defaults/main.yml
@@ -33,3 +33,7 @@ docker_platform_privileged: false
 # A list of tmpfs filesystem paths to be passed to the container
 docker_platform_tmpfs: []
 
+# Ansible hostvars that should be associated with the ansible test "host" created by this role
+#  stored in the format `name: value`
+docker_platform_hostvars: {}
+

--- a/roles/docker_platform/tasks/create.yml
+++ b/roles/docker_platform/tasks/create.yml
@@ -55,7 +55,7 @@
 
 - name: Build docker volume list
   ansible.builtin.set_fact:
-    __docker_platform_volume_list: "{{ docker_platform_volumes + ['/sys/fs/cgroup/molecule-ci.scope:/sys/fs/cgroup:rw']
+    __docker_platform_volume_list: "{{ docker_platform_volumes + ['/sys/fs/cgroup:/sys/fs/cgroup:rw']
       if docker_platform_systemd
       else docker_platform_volumes }}"
 

--- a/roles/docker_platform/tasks/present.yml
+++ b/roles/docker_platform/tasks/present.yml
@@ -53,13 +53,15 @@
 
 - name: Add container to molecule_inventory
   vars:
+    __docker_platform_inventory_partial_hostvars: "{{ {
+      'ansible_connection': 'community.docker.docker'
+      } | combine(docker_platform_hostvars, recursive=true) }}"
     __docker_platform_inventory_partial_yaml: |
       all:
         children:
           molecule:
             hosts:
-              "{{ docker_platform_name }}":
-                ansible_connection: community.docker.docker
+              "{{ docker_platform_name }}": {{ __docker_platform_inventory_partial_hostvars }}
   ansible.builtin.set_fact:
     __docker_platform_molecule_inventory: >
       {{ __docker_platform_current_molecule_inventory | default({}) | combine(__docker_platform_inventory_partial_yaml | from_yaml, recursive=true) }}

--- a/roles/init/tasks/asserts.yml
+++ b/roles/init/tasks/asserts.yml
@@ -11,14 +11,6 @@
     fail_msg: Global configuration option for init role is not sane
     success_msg: Sanity check passed
 
-- name: Check for collection identification
-  ansible.builtin.assert:
-    that:
-      - __init_collection_config.collection_info.namespace is truthy
-      - __init_collection_config.collection_info.name is truthy
-    fail_msg: Collection ID information not found! This role must be run from within its collection!
-    success_msg: Collection ID found
-
 - name: Check for project file paths
   ansible.builtin.stat:
     path: "{{ __init_item }}"

--- a/roles/init/tasks/main.yml
+++ b/roles/init/tasks/main.yml
@@ -1,12 +1,6 @@
 ---
 # tasks file for init
 
-- name: Load parent collection config
-  # NOTE: This will break if this role is moved outside of the collection!
-  ansible.builtin.include_vars:
-    file: "{{ role_path }}/../../MANIFEST.json"
-    name: __init_collection_config
-
 - name: Check configuration data
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/asserts.yml"
 

--- a/roles/init/templates/collections.yml.j2
+++ b/roles/init/templates/collections.yml.j2
@@ -2,5 +2,5 @@
 
 collections:
   - name: community.docker
-  - name: syndr.molecule
+  - name: {{ ansible_collection_name }}
 

--- a/roles/init/templates/create.yml.j2
+++ b/roles/init/templates/create.yml.j2
@@ -3,7 +3,7 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - name: Create platform
+    - name: Create docker platform(s)
       ansible.builtin.include_role:
         name: {{ ansible_collection_name }}.docker_platform
       vars:
@@ -16,6 +16,7 @@
         docker_platform_privileged: "{{ item.privileged | default (false) }}"
         docker_platform_hostvars: "{{ item.hostvars | default({}) }}"
         docker_platform_state: present
+      when: item.type == 'docker'
       loop: "{{ molecule_yml.platforms }}"
       loop_control:
         label: item.name
@@ -40,15 +41,24 @@
         filter:
           - ansible_service_mgr
 
-    - name: Wait for systemd to complete initialization.
-      ansible.builtin.command: systemctl is-system-running
-      register: systemctl_status
-      until: >
-        'running' in systemctl_status.stdout or
-        'degraded' in systemctl_status.stdout
-      retries: 30
-      delay: 5
+    - name: Check on Systemd
+      block:
+        - name: Wait for systemd to complete initialization.
+          ansible.builtin.command: systemctl is-system-running
+          register: systemctl_status
+          until: >
+            'running' in systemctl_status.stdout or
+            'degraded' in systemctl_status.stdout
+          retries: 30
+          delay: 5
+          changed_when: false
+          failed_when: systemctl_status.rc > 1
+
+        - name: Check systemd status
+          ansible.builtin.assert:
+            that:
+              - systemctl_status.stdout == 'running'
+            fail_msg: Systemd-enabled container does not have a healthy Systemd!
+            success_msg: Systemd is running
       when: ansible_service_mgr == 'systemd'
-      changed_when: false
-      failed_when: systemctl_status.rc > 1
 

--- a/roles/init/templates/create.yml.j2
+++ b/roles/init/templates/create.yml.j2
@@ -5,7 +5,7 @@
   tasks:
     - name: Create platform
       ansible.builtin.include_role:
-        name: {{ __init_collection_config.collection_info.namespace }}.{{ __init_collection_config.collection_info.name }}.docker_platform
+        name: {{ ansible_collection_name }}.docker_platform
       vars:
 {% raw %}
         docker_platform_name: "{{ item.name }}"

--- a/roles/init/templates/create.yml.j2
+++ b/roles/init/templates/create.yml.j2
@@ -14,6 +14,7 @@
         docker_platform_modify_image: "{{ item.modify_image | default(false) }}"
         docker_platform_modify_image_buildpath: "{{ item.modify_image_buildpath | default(molecule_ephemeral_directory + '/build') }}"
         docker_platform_privileged: "{{ item.privileged | default (false) }}"
+        docker_platform_hostvars: "{{ item.hostvars | default({}) }}"
         docker_platform_state: present
       loop: "{{ molecule_yml.platforms }}"
       loop_control:

--- a/roles/init/templates/destroy.yml.j2
+++ b/roles/init/templates/destroy.yml.j2
@@ -6,7 +6,7 @@
   tasks:
     - name: Remove platform
       ansible.builtin.include_role:
-        name: {{ __init_collection_config.collection_info.namespace }}.{{ __init_collection_config.collection_info.name }}.docker_platform
+        name: {{ ansible_collection_name }}.docker_platform
       vars:
 {% raw %}
         docker_platform_name: "{{ inventory_hostname }}"

--- a/roles/init/templates/molecule.yml.j2
+++ b/roles/init/templates/molecule.yml.j2
@@ -19,6 +19,7 @@ platforms:
     modify_image_buildpath: {{ init_platform.config.modify_image_buildpath }}
 {% endif %}
     privileged: {{ init_platform.config.privileged | default(false) }}
+    hostvars: {}
 {% endif %}
 {% endfor %}
 provisioner:

--- a/roles/init/templates/prepare.yml.j2
+++ b/roles/init/templates/prepare.yml.j2
@@ -2,6 +2,7 @@
 
 - name: Prepare controller for execution
   hosts: localhost
+  tags: always
   tasks:
     - name: Configure for standalone role testing
       ansible.builtin.include_role:
@@ -11,10 +12,50 @@
 
 - name: Prepare target host for execution
   hosts: molecule
+  tags: always
   tasks:
-    - name: Add your host preparation tasks here!
-      ansible.builtin.debug:
-        msg: "IE: adding system users, installing required packages, etc."
+    ##
+    # Creating an admin service account for Molecule/Ansible to use for testing
+    #
+    #   - If you run Ansible as a service account (you should) on your hosts and
+    #     not as root, it is wise to also test as a non-root user!
+    #
+    #   - To use this account, add the following to any plays targeting test
+    #     infrastructure (such as in converge.yml):
+    #
+    #         vars:
+    #           ansible_user: molecule_runner
+    ##
+{% raw %}
+    - name: Create ansible service account
+      vars:
+        molecule_user: molecule_runner
+      block:
+        - name: Create ansible group
+          ansible.builtin.group:
+            name: "{{ molecule_user }}"
+
+        - name: Create ansible user
+          ansible.builtin.user:
+            name: "{{ molecule_user }}"
+            group: "{{ molecule_user }}"
+
+        - name: Sudoers.d directory exists
+          ansible.builtin.file:
+            path: /etc/sudoers.d
+            state: directory
+            owner: root
+            group: root
+            mode: 0751
+
+        - name: Ansible user has sudo
+          ansible.builtin.copy:
+            content: |
+              {{ molecule_user }}  ALL=(ALL)  NOPASSWD: ALL
+            dest: /etc/sudoers.d/ansible
+            owner: root
+            group: root
+            mode: 0600
 
     - name: "Save vars to host (IE: generated test credentials, etc.)"
       become: true
@@ -27,7 +68,6 @@
             group: root
             mode: 0744
 
-{% raw %}
         - name: Persistent data saved to local Ansible facts
           ansible.builtin.copy:
             dest: /etc/ansible/facts.d/molecule.fact
@@ -36,4 +76,8 @@
             group: root
             mode: 0644
 {% endraw %}
+
+    - name: Add your host preparation tasks here!
+      ansible.builtin.debug:
+        msg: "IE: adding system users, installing required packages, etc."
 


### PR DESCRIPTION
Add support for specifying Ansible hostvars on a platform.

Fix cgroup namespace for docker platform.

Add more recommended configuration to `prepare.yml` template.

Add more documentation.