### PR TITLE
Add default values for case where collection manifest is not accessible

### DIFF
--- a/roles/init/defaults/main.yml
+++ b/roles/init/defaults/main.yml
@@ -47,3 +47,10 @@ init_file_backup: true
 #  - Set to "" to disable
 init_ansible_secret_path: ""
 
+# Configuration defaults to be used if the collection manifest is not accessible
+init_collection_defaults:
+  repository: https://github.com/syndr/ansible-collection-molecule
+  name: molecule
+  namespace: syndr
+  version: latest
+

--- a/roles/init/tasks/main.yml
+++ b/roles/init/tasks/main.yml
@@ -60,23 +60,22 @@
         verbosity: 1
       ignore_errors: true
 
-    - name: Collection meta data is valid
-      ansible.builtin.assert:
-        that:
-          - __init_collection_meta is not failed
-          - __init_collection_meta.content is defined
-          - (__init_collection_meta.content | b64decode | from_json).collection_info.version is defined
-        fail_msg: "Collection meta data not found! Check the collection configuration."
-        success_msg: "Collection meta data found"
-
     - name: Extract collection meta info
+      when:
+        - __init_collection_meta is not failed
+        - __init_collection_meta.content is defined
+        - (__init_collection_meta.content | b64decode | from_json).collection_info.version is defined
       ansible.builtin.set_fact:
         __init_collection_meta: "{{ (__init_collection_meta.content | b64decode | from_json) }}"
 
-- name: Get collection version
-  when: init_collection_version is not truthy
+- name: Set collection information
   ansible.builtin.set_fact:
-    init_collection_version: "{{ __init_collection_meta.collection_info.version }}"
+    init_collection_version: >-
+      "{{ init_collection_version if init_collection_version is truthy
+      else __init_collection_meta.collection_info.version | default(init_collection_defaults.version) }}"
+    __init_collection_name: "{{ __init_collection_meta.collection_info.name | default(init_collection_defaults.name) }}"
+    __init_collection_namespace: "{{ __init_collection_meta.collection_info.namespace | default(init_collection_defaults.namespace) }}"
+    __init_collection_repository: "{{ __init_collection_meta.collection_info.repository | default(init_collection_defaults.repository) }}"
 
 - name: Deploy molecule configuration
   ansible.builtin.template:

--- a/roles/init/templates/collections.yml.j2
+++ b/roles/init/templates/collections.yml.j2
@@ -3,10 +3,10 @@
 collections:
   - name: community.docker
 {% if init_collection_source == 'git' %}
-  - name: git+{{ __init_collection_meta.collection_info.repository }}.git
+  - name: git+{{ __init_collection_repository }}.git
     type: git
 {% elif init_collection_source == 'galaxy' %}
-  - name: {{ __init_collection_meta.collection_info.namespace }}.{{ __init_collection_meta.collection_info.name }}
+  - name: {{ __init_collection_namespace }}.{{ __init_collection_name }}
 {% endif %}
     version: {{ init_collection_version }}
 


### PR DESCRIPTION
Fixes issue primarily affecting CI, where the `init` role fails if it cannot read the collection manifest.