### PR TITLE
Add Linode platform support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,6 @@ ansible-lint
 requests>=2.32.3
 molecule==24.12.0
 boto3[crt]
-
+polling # Required for Linode Scenario which uses linode.cloud module
+linode_api4>=5.29.0 # Official Python library for Linode API v4
+ansible-specdoc>=0.0.19 # Required by linode.cloud modules

--- a/roles/linode_platform/README.md
+++ b/roles/linode_platform/README.md
@@ -1,0 +1,125 @@
+molecule.linode_platform
+=========
+
+Create an Akamai Linode platform for Molecule.
+
+This role is intended to be used via the `molecule.platform` role that is included with this collection, and should not be referenced directly in a playbook.
+
+Configuration is done via the `platforms` section of the `molecule.yml` file in your Molecule scenario directory.
+
+Required configuration options are:
+
+- `name`: The name of the platform (string)
+- `type`: `linode`
+- `image`: The Linode image ID to use for the instance (string, e.g., "linode/ubuntu22.04")
+- `region`: The Linode region to deploy the instance in (string, e.g., "us-east")
+- `type_spec`: The Linode instance type specification (string, e.g., "g6-nanode-1")
+
+Optional configuration options are:
+
+- `boot_wait_seconds`: The number of seconds to wait for the instance to boot (integer, default: 10)
+- `instance_creation_timeout`: The timeout in seconds for instance creation (integer, default: 300)
+- `private_key_path`: The path to the private key file for SSH (string, default: `<molecule_ephemeral_directory>/id_rsa`)
+- `public_key_path`: The path to the public key file for SSH (string, default: `<molecule_ephemeral_directory>/id_rsa.pub`)
+- `ssh_user`: The SSH user to use for connecting to the instance (string, default: "root")
+- `ssh_port`: The SSH port to use for connecting to the instance (integer, default: 22)
+- `stackscript_id`: The ID of a StackScript to run on instance creation (string, default: "")
+- `stackscript_data`: Data to pass to the StackScript (dictionary, default: {})
+- `tags`: A dictionary of tags to apply to the instance (dictionary, default: {})
+
+Requirements
+------------
+
+**Python Modules**
+- `linode_api4` (>= 5.29.0) - Official Python library for Linode API v4
+- `polling` - Required for asynchronous operations
+- `ansible-specdoc` (>= 0.0.19) - Required by linode.cloud modules
+
+## Linode API Configuration
+
+These tests require a Linode API token with the following permissions:
+
+- **Linodes**: Read/Write access
+- **SSH Keys**: Read/Write access
+
+To create an API token:
+1. Log in to the [Linode Cloud Manager](https://cloud.linode.com/)
+2. Navigate to your profile → API Tokens
+3. Click "Create a Personal Access Token"
+4. Set the required permissions and expiry
+5. Save the token securely - it will only be shown once
+
+Role Variables
+--------------
+
+In order to connect to Linode, you will need the following environment variable to be set:
+
+```bash
+export LINODE_API_TOKEN="your-linode-api-token-here"
+```
+
+This token must have appropriate permissions to create, list, and destroy Linode instances and SSH keys.
+
+Full role configuration options are available in the [defaults/main.yml](defaults/main.yml) file.
+
+Dependencies
+------------
+
+**Collections**
+- `linode.cloud`
+
+Example Playbook
+----------------
+
+This role is intended to be used via the `molecule.platform` role that is included with this collection, and should not be referenced directly in a playbook.
+
+Configuration is done via the `platforms` section of the `molecule.yml` file in your Molecule scenario directory.
+
+```yaml
+platforms:
+  - name: test-ubuntu22
+    type: linode
+    image: linode/ubuntu22.04
+    region: us-east
+    type_spec: g6-nanode-1
+    ssh_user: root
+  - name: test-rocky9
+    type: linode
+    image: linode/rocky9
+    region: us-east
+    type_spec: g6-nanode-1
+    ssh_user: root
+```
+
+To utilize this role, use the `platform` role that is included with this collection in your `create.yml` playbook!
+
+```yaml
+- name: Create
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Create platform(s)
+      ansible.builtin.include_role:
+        name: syndr.molecule.platform
+
+# We want to avoid errors like "Failed to create temporary directory"
+- name: Validate that inventory was refreshed
+  hosts: molecule
+  gather_facts: false
+  tasks:
+    - name: Check uname
+      ansible.builtin.raw: uname -a
+      register: result
+      changed_when: false
+
+    - name: Display uname info
+      ansible.builtin.debug:
+        msg: "{{ result.stdout }}"
+
+```
+
+
+License
+-------
+
+MIT

--- a/roles/linode_platform/defaults/main.yml
+++ b/roles/linode_platform/defaults/main.yml
@@ -1,0 +1,56 @@
+---
+# defaults file for linode_platform
+
+# Name of this Molecule platform
+linode_platform_name: instance
+
+# Whether this platform should be deployed (present/absent)
+linode_platform_state: "{{ platform_target_state | default('present') }}"
+
+# Molecule platform configuration (list of dictionaries)
+linode_platform_definition: "{{ [platform_target_config] if platform_target_config is defined else (molecule_yml.platforms | default([])) }}"
+
+# Merge the defaults with any options provided to this role
+linode_platforms: >-
+  {%- set __platforms = [] -%}
+  {%- for __platform in linode_platform_definition -%}
+    {%- set __platform = linode_platform_defaults | combine(__platform) -%}
+    {%- set _ = __platforms.append(__platform) -%}
+  {%- endfor -%}
+  {{ __platforms }}
+
+# Run config handling - prioritize existing run ID from file
+linode_platform_default_run_id: "{{ linode_platform_run_config_from_file.run_id | default(lookup('password', '/dev/null chars=ascii_lowercase length=5')) }}"
+linode_platform_default_run_config:
+  run_id: "{{ linode_platform_default_run_id }}"
+
+linode_platform_run_config_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/linode-platform-run-config.yml"
+linode_platform_run_config_from_file: "{{ (lookup('file', linode_platform_run_config_path, errors='ignore') or '{}') | from_yaml }}"
+linode_platform_run_config: '{{ linode_platform_default_run_config | combine(linode_platform_run_config_from_file) }}'
+
+# Platform settings handling
+linode_platform_default_boot_wait_seconds: 10
+linode_platform_default_instance_creation_timeout: 300
+linode_platform_default_type_spec: g6-nanode-1
+linode_platform_default_region: us-east
+linode_platform_default_private_key_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/id_rsa"
+linode_platform_default_public_key_path: "{{ linode_platform_default_private_key_path }}.pub"
+linode_platform_default_ssh_user: root
+linode_platform_default_ssh_port: 22
+linode_platform_default_stackscript_id: ""
+linode_platform_default_stackscript_data: {}
+
+linode_platform_defaults:
+  boot_wait_seconds: "{{ linode_platform_default_boot_wait_seconds }}"
+  instance_creation_timeout: "{{ linode_platform_default_instance_creation_timeout }}"
+  type_spec: "{{ linode_platform_default_type_spec }}"
+  region: "{{ linode_platform_default_region }}"
+  private_key_path: "{{ linode_platform_default_private_key_path }}"
+  public_key_path: "{{ linode_platform_default_public_key_path }}"
+  ssh_user: "{{ linode_platform_default_ssh_user }}"
+  ssh_port: "{{ linode_platform_default_ssh_port }}"
+  stackscript_id: "{{ linode_platform_default_stackscript_id }}"
+  stackscript_data: "{{ linode_platform_default_stackscript_data }}"
+  image: ""
+  name: ""
+  tags: {}

--- a/roles/linode_platform/handlers/main.yml
+++ b/roles/linode_platform/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for linode_platform

--- a/roles/linode_platform/meta/main.yml
+++ b/roles/linode_platform/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  role_name: linode_platform
+  namespace: syndr
+  description: Provision and deprovision a Linode-based Molecule platform using Ansible.
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: MIT
+
+  min_ansible_version: 2.16
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/linode_platform/tasks/absent.yml
+++ b/roles/linode_platform/tasks/absent.yml
@@ -1,0 +1,79 @@
+---
+# Remove Linode test resources
+
+- name: Linode Deprovision | Look up Linode instances by tag
+  linode.cloud.instance_list:
+  register: __linode_instance_info
+
+- name: Linode Deprovision | Set instances to destroy
+  vars:
+    __all_instances: "{{ __linode_instance_info.instances }}"
+    __target_tag: "molecule-run-id:{{ linode_platform_run_config.run_id | default('') }}"
+    __linode_platform_existing_instances: "{{ __all_instances | selectattr('tags', 'contains', __target_tag) | list }}"
+  ansible.builtin.set_fact:
+    __linode_instances_to_destroy: "{{ __linode_platform_existing_instances }}"
+
+- name: Linode Deprovision | Validate safety of destroy operation
+  ansible.builtin.assert:
+    that:
+      - __linode_instances_to_destroy | length <= linode_platforms | length
+    fail_msg: "More instances found than expected! Found {{ __linode_instances_to_destroy | length }} instances."
+    success_msg: "{{ __linode_instances_to_destroy | length }} instances found for termination."
+
+- name: Linode Deprovision | Remove instances
+  when: __linode_instances_to_destroy | length > 0
+  block:
+    - name: Linode Deprovision | Destroy ephemeral Linode instances
+      loop: "{{ __linode_instances_to_destroy }}"
+      loop_control:
+        loop_var: __linode_instance_to_destroy
+        label: "{{ __linode_instance_to_destroy.label }}"
+      linode.cloud.instance:
+        label: "{{ __linode_instance_to_destroy.label }}"
+        state: absent
+      register: __linode_instance_destroy_jobs
+      async: 300
+      poll: 0
+
+    - name: Linode Deprovision | Instance destruction is complete
+      loop: "{{ __linode_instance_destroy_jobs.results }}"
+      loop_control:
+        loop_var: __linode_instance_destroy_job
+        label: "{{ __linode_instance_destroy_job.__linode_instance_to_destroy.label }}"
+      ansible.builtin.async_status:
+        jid: "{{ __linode_instance_destroy_job.ansible_job_id }}"
+      register: __linode_instance_destroy_results
+      until: __linode_instance_destroy_results.finished
+      retries: "{{ (300 / 5) | int }}"
+      delay: 5
+
+    - name: Linode Deprovision | Clean up async cache
+      loop: "{{ __linode_instance_destroy_jobs.results }}"
+      loop_control:
+        loop_var: __linode_instance_destroy_job
+        label: "{{ __linode_instance_destroy_job.__linode_instance_to_destroy.label }}"
+      ansible.builtin.async_status:
+        jid: "{{ __linode_instance_destroy_job.ansible_job_id }}"
+        mode: cleanup
+
+    - name: Linode Deprovision | Destroy ephemeral SSH keys
+      loop: "{{ __linode_instances_to_destroy }}"
+      loop_control:
+        loop_var: __linode_instance_destroyed
+        label: "{{ __linode_instance_destroyed.label }}"
+      vars:
+        __ssh_key_label: "molecule-{{ linode_platform_run_config.run_id | default('') }}-{{ __linode_instance_destroyed.tags | select('match', '^instance:.*') | map('regex_replace', '^instance:', '') | first }}"
+      linode.cloud.ssh_key:
+        label: "{{ __ssh_key_label }}"
+        state: absent
+      failed_when: false  # SSH keys might already be cleaned up
+
+- name: Linode Deprovision | Remove linode instance config file  
+  # Only run when this execution is operating on the full scenario configuration
+  #  - we want to avoid removing the instance config if there may still be deployed instances
+  #    (IE: if this role is called on individual items in the platforms list)
+  #  - Molecule's builtin ephemeral dir cleanup should remove the instance config in this case
+  when: linode_platform_definition | length == molecule_yml.platforms | default([]) | length
+  ansible.builtin.file:
+    path: "{{ linode_platform_run_config_path }}"
+    state: absent

--- a/roles/linode_platform/tasks/main.yml
+++ b/roles/linode_platform/tasks/main.yml
@@ -1,0 +1,60 @@
+---
+# tasks file for linode_platform
+
+- name: 🐞 Show linode_platform_definition
+  ansible.builtin.debug:
+    var: linode_platform_definition
+    verbosity: 1
+
+- name: 🦋 Show linode_platforms
+  ansible.builtin.debug:
+    var: linode_platforms
+    verbosity: 1
+
+- name: Validate configuration
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/validate_cfg.yml"
+
+- name: Platform is deployed
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/present.yml"
+  when: linode_platform_state == 'present'
+
+- name: Platform is not deployed
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/absent.yml"
+  when: linode_platform_state == 'absent'
+
+- name: Display platform configuration
+  ansible.builtin.debug:
+    var: linode_platform_instance_configs
+    verbosity: 1
+
+- name: Export platform configuration
+  ansible.builtin.set_fact:
+    platform_exported_config: >-
+      {%- set __platform_instances = {} -%}
+      {%- for __platform in __platform_config -%}
+        {%- if linode_platform_instance_configs is defined -%}
+          {%- set __platform_instance_config = linode_platform_instance_configs | selectattr('instance', 'equalto', __platform.name) | first -%}
+          {%- set __platform_hostvars_merged = {
+              'ansible_host': __platform_instance_config.address,
+              'ansible_port': __platform_instance_config.port,
+              'ansible_user': __platform_instance_config.user,
+              'ansible_ssh_private_key_file': __platform_instance_config.identity_file,
+              'linode_instance_id': __platform_instance_config.instance_id,
+            } -%}
+          {%- endif -%}
+        {%- set _ = __platform_instances.update({
+          __platform.name: {
+            'hostvars': __platform.hostvars | default({})
+              | combine(linode_platform_hostvars_base)
+              | combine(__platform_hostvars_merged | default({})),
+            'instance_config': __platform_instance_config | default({})
+          }
+        }) -%}
+      {%- endfor -%}
+      {{ __platform_instances }}
+
+- name: Show exported platform configuration
+  ansible.builtin.debug:
+    var: platform_exported_config
+    verbosity: 1
+

--- a/roles/linode_platform/tasks/present.yml
+++ b/roles/linode_platform/tasks/present.yml
@@ -1,0 +1,179 @@
+---
+# Deploy desired Linode platform(s)
+#
+# Expected input:
+#  - linode_platform: The current Molecule platform configurations (list)
+#
+
+- name: Linode Provision | Write run config to file
+  ansible.builtin.copy:
+    dest: "{{ linode_platform_run_config_path }}"
+    content: "{{ linode_platform_run_config | to_yaml }}"
+    mode: "0600"
+
+- name: Linode Provision | Generate local key pairs
+  loop: "{{ linode_platforms }}"
+  loop_control:
+    loop_var: __linode_platform
+    label: "{{ __linode_platform.name }}"
+  community.crypto.openssh_keypair:
+    path: "{{ __linode_platform.private_key_path }}"
+    type: rsa
+    size: 2048
+    regenerate: never
+  register: __linode_platform_local_keypairs
+
+- name: Linode Provision | Create SSH keys in Linode
+  loop: "{{ linode_platforms }}"
+  loop_control:
+    loop_var: __linode_platform
+    label: "{{ __linode_platform.name }}"
+  vars:
+    __linode_platform_ssh_pubkey: "{{ (__linode_platform_local_keypairs.results | selectattr('__linode_platform.name', 'equalto', __linode_platform.name) | first).public_key }}"
+  linode.cloud.ssh_key:
+    label: "molecule-{{ linode_platform_run_config.run_id }}-{{ __linode_platform.name }}"
+    ssh_key: "{{ __linode_platform_ssh_pubkey }}"
+    state: present
+  register: __linode_platform_ssh_keys
+
+- name: Linode Provision | Create ephemeral Linode instances
+  loop: "{{ linode_platforms }}"
+  loop_control:
+    loop_var: __linode_platform
+    label: "{{ __linode_platform.name }}"
+  vars:
+    __linode_platform_ssh_pubkey: "{{ (__linode_platform_local_keypairs.results | selectattr('__linode_platform.name', 'equalto', __linode_platform.name) | first).public_key }}"
+    __linode_platform_generated_tags:
+      - "instance:{{ __linode_platform.name }}"
+      - "molecule-run-id:{{ linode_platform_run_config.run_id }}"
+      - "molecule-{{ __linode_platform.name }}"
+    __linode_platform_tags: "{{ __linode_platform_generated_tags + (__linode_platform.tags | default([]) | map('string') | list) }}"
+  linode.cloud.instance:
+    label: "molecule-{{ __linode_platform.name }}"
+    region: "{{ __linode_platform.region }}"
+    image: "{{ __linode_platform.image }}"
+    type: "{{ __linode_platform.type_spec }}"
+    authorized_keys:
+      - "{{ __linode_platform_ssh_pubkey }}"
+    tags: "{{ __linode_platform_tags }}"
+    stackscript_id: "{{ __linode_platform.stackscript_id if __linode_platform.stackscript_id else omit }}"
+    stackscript_data: "{{ __linode_platform.stackscript_data if __linode_platform.stackscript_data else omit }}"
+    state: present
+    wait_timeout: "{{ __linode_platform.instance_creation_timeout | int }}"
+  register: __linode_instance_creation_jobs
+  async: "{{ __linode_platform.instance_creation_timeout | int }}"
+  poll: 0
+  changed_when: false   # Asynchronous task, always marked as changed
+
+- name: Linode Provision | Print instance creation job status
+  ansible.builtin.debug:
+    var: __linode_instance_creation_jobs
+    verbosity: 1
+
+- name: Linode Provision | Instance creation is complete
+  loop: "{{ __linode_instance_creation_jobs.results }}"
+  loop_control:
+    loop_var: __linode_instance_creation_job
+    label: "{{ __linode_instance_creation_job.__linode_platform.name }}"
+  ansible.builtin.async_status:
+    jid: "{{ __linode_instance_creation_job.ansible_job_id }}"
+  register: __linode_instance_creation_results
+  until: __linode_instance_creation_results.finished
+  retries: "{{ (__linode_instance_creation_job.__linode_platform.instance_creation_timeout | int / 10) | int }}"
+  delay: 10
+  changed_when: false
+
+- name: Linode Provision | Clean up async cache
+  loop: "{{ __linode_instance_creation_jobs.results }}"
+  loop_control:
+    loop_var: __linode_instance_creation_job
+    label: "{{ __linode_instance_creation_job.__linode_platform.name }}"
+  ansible.builtin.async_status:
+    jid: "{{ __linode_instance_creation_job.ansible_job_id }}"
+    mode: cleanup
+
+- name: Linode Provision | Print instance creation result
+  ansible.builtin.debug:
+    var: __linode_instance_creation_results
+    verbosity: 1
+
+# Referenced in exported platform configuration -- see main.yml
+- name: Linode Provision | Collect instance configs
+  loop: "{{ __linode_instance_creation_results.results }}"
+  loop_control:
+    loop_var: __linode_instance_record
+    label: "{{ __linode_instance_record.__linode_instance_creation_job.__linode_platform.name }}"
+  vars:
+    __linode_platform_instance_definition: "{{ linode_platforms
+      | selectattr('name', 'equalto', __linode_instance_record.__linode_instance_creation_job.__linode_platform.name) | first }}"
+    __linode_platform_instance_data: "{{ __linode_instance_record.instance }}"
+    __linode_platform_instance:
+      instance: "{{ __linode_platform_instance_definition.name }}"
+      # Linode API returns IP addresses as arrays, extract first IP for export template compatibility or instance_config.yml will fail to create in the platform role and you will be sad and angry
+      address: "{{ (__linode_platform_instance_data.ipv4.public | default(__linode_platform_instance_data.ipv4) | default(__linode_platform_instance_data.ip_address)) | first }}"
+      user: "{{ __linode_platform_instance_definition.ssh_user }}"
+      port: "{{ __linode_platform_instance_definition.ssh_port }}"
+      identity_file: "{{ __linode_platform_instance_definition.private_key_path }}"
+      instance_id: "{{ __linode_platform_instance_data.id }}"
+      molecule_run_id: "{{ linode_platform_run_config.run_id }}"
+  ansible.builtin.set_fact:
+    linode_platform_instance_configs: "{{ linode_platform_instance_configs | default([]) + [__linode_platform_instance] }}"
+
+- name: Linode Provision | Show collected instance configs
+  ansible.builtin.debug:
+    var: linode_platform_instance_configs
+    verbosity: 1
+
+- name: Linode Provision | Launch boot wait tasks
+  loop: "{{ linode_platforms }}"
+  loop_control:
+    loop_var: __linode_platform
+    label: "{{ __linode_platform.name }}"
+  ansible.builtin.wait_for:
+    timeout: "{{ __linode_platform.boot_wait_seconds }}"
+  register: __linode_platform_boot_wait_job
+  async: "{{ __linode_platform.boot_wait_seconds | int + 10 }}" # Add 10 seconds to the timeout to allow for the wait_for task to complete
+  poll: 0
+  changed_when: false
+
+- name: Linode Provision | Wait for boot process to finish
+  loop: "{{ __linode_platform_boot_wait_job.results }}"
+  loop_control:
+    loop_var: __linode_platform_boot_wait_result
+    label: "{{ __linode_platform_boot_wait_result.__linode_platform.name }}"
+  ansible.builtin.async_status:
+    jid: "{{ __linode_platform_boot_wait_result.ansible_job_id }}"
+  register: __linode_platform_boot_wait_results
+  until: __linode_platform_boot_wait_results.finished
+  retries: "{{ (__linode_platform_boot_wait_result.__linode_platform.boot_wait_seconds | int / 10) | int }}"
+  delay: 10
+  changed_when: false
+
+- name: Linode Provision | Clean up async cache
+  loop: "{{ __linode_platform_boot_wait_job.results }}"
+  loop_control:
+    loop_var: __linode_platform_boot_wait_result
+    label: "{{ __linode_platform_boot_wait_result.__linode_platform.name }}"
+  ansible.builtin.async_status:
+    jid: "{{ __linode_platform_boot_wait_result.ansible_job_id }}"
+    mode: cleanup
+
+- name: Linode Provision | SSH connectivity check is successful
+  loop: "{{ linode_platforms }}"
+  loop_control:
+    loop_var: __linode_platform
+    label: "{{ __linode_platform.name }}"
+  vars:
+    __linode_platform_instance_config: "{{ linode_platform_instance_configs
+      | selectattr('instance', 'equalto', __linode_platform.name) | first }}"
+  ansible.builtin.wait_for:
+    host: "{{ __linode_platform_instance_config.address }}"
+    port: "{{ __linode_platform_instance_config.port }}"
+    search_regex: SSH
+    delay: 10
+    timeout: 320
+    msg: "SSH connectivity check to {{ __linode_platform_instance_config.address }} on port {{ __linode_platform_instance_config.port }} failed"
+  register: __linode_platform_ssh_connectivity_check
+  until: "'Connection reset by peer' not in __linode_platform_ssh_connectivity_check.module_stderr | default('')"
+  retries: 6
+  delay: 10

--- a/roles/linode_platform/tasks/validate_cfg.yml
+++ b/roles/linode_platform/tasks/validate_cfg.yml
@@ -1,0 +1,27 @@
+---
+# Validate Linode platform configuration
+
+- name: Validate required Linode configuration
+  loop: "{{ linode_platforms }}"
+  loop_control:
+    loop_var: __linode_platform
+    label: "{{ __linode_platform.name }}"
+  ansible.builtin.assert:
+    that:
+      - __linode_platform.name is defined
+      - __linode_platform.name | length > 0
+      - __linode_platform.image is defined
+      - __linode_platform.image | length > 0
+      - __linode_platform.region is defined
+      - __linode_platform.region | length > 0
+      - __linode_platform.type_spec is defined
+      - __linode_platform.type_spec | length > 0
+    fail_msg: "Platform '{{ __linode_platform.name | default('undefined') }}' is missing required configuration"
+    quiet: true
+
+- name: Validate LINODE_API_TOKEN is set
+  ansible.builtin.assert:
+    that:
+      - lookup('env', 'LINODE_API_TOKEN') | length > 0
+    fail_msg: "LINODE_API_TOKEN environment variable must be set"
+    quiet: true

--- a/roles/linode_platform/vars/main.yml
+++ b/roles/linode_platform/vars/main.yml
@@ -1,0 +1,8 @@
+---
+# vars file for linode_platform
+
+# Base hostvars for Linode instances that should always be present
+# NOTE: These are exported on platform removal as well. Include default values if data will not always exist!
+linode_platform_hostvars_base:
+  ansible_connection: ssh
+


### PR DESCRIPTION
I've tested this with [ansible-role-system](https://github.com/syndr/ansible-role-system), but the catch is that the role also needs linode support. I ran this feature branch of `ansible-collection-molecule` against [this feature branch on my fork of ansible-role-system](https://github.com/WesleyDavid/ansible-role-system/tree/feat/role-system-linode).

I was able to run `molecule test -s role-system-linode` from within the molecule scenarios of the `ansible-role-system` role. I successfully created four Linodes, ran the suite of tests, then the four nodes were destroyed as were the SSH keys in the Linode account.

I can provided a Linode account and API key for you to test with as well.