### PR TITLE
Bump tool versions, fix conditionals

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: syndr
 name: molecule
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 2.0.0
+version: 2.0.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,7 +1,7 @@
 ---
 # Collections must specify a minimum required ansible version to upload
 # to galaxy
-requires_ansible: '>=2.12'
+requires_ansible: '>=2.16'
 
 # Content that Ansible needs to load from another location or that has
 # been deprecated/removed

--- a/molecule/resources/converge.yml
+++ b/molecule/resources/converge.yml
@@ -28,7 +28,7 @@
 
     - name: Verify kernel type
       ansible.builtin.assert:
-        that: result.stdout | regex_search("^Linux")
+        that: result.stdout | regex_search("^Linux") is truthy
 
     - name: Do preparation
       block:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # Supported python runtime environment for this project
 
-ansible-core==2.16.14
+ansible-core>=2.19.1
 ansible-lint
 requests>=2.32.3
-molecule==24.12.0
+molecule>=25.7.0
 boto3[crt]
 polling # Required for Linode Scenario which uses linode.cloud module
 linode_api4>=5.29.0 # Official Python library for Linode API v4

--- a/roles/ec2_platform/tasks/present.yml
+++ b/roles/ec2_platform/tasks/present.yml
@@ -54,8 +54,22 @@
     label: "{{ __ec2_platform.name }}"
   ansible.builtin.assert:
     that:
-      - __ec2_platform.image or ((__ec2_platform_ami_info.results | selectattr('__ec2_platform.name', 'equalto', __ec2_platform.name)).images | length > 0)
-      - __ec2_platform.vpc_id or ((__ec2_platform_subnet_info.results | selectattr('__ec2_platform.name', 'equalto', __ec2_platform.name)).subnets | length > 0)
+      - >-
+        (
+          __ec2_platform.image is truthy
+          or
+          ((__ec2_platform_ami_info.results
+            | selectattr('__ec2_platform.name', 'equalto', __ec2_platform.name)).images
+            | length > 0)
+        )
+      - >-
+        (
+          __ec2_platform.vpc_id is truthy
+          or
+          ((__ec2_platform_subnet_info.results
+            | selectattr('__ec2_platform.name', 'equalto', __ec2_platform.name)).subnets
+            | length > 0)
+        )
     quiet: true
 
 - name: Show generated keypairs


### PR DESCRIPTION
Fix broken conditionals (errors on Ansible 2.19)

Update tool versions used in CI
 - ansible-core --> 2.19.1
 - molecule --> 25.7.0